### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Join us on IRC on **#rust-sci** at *irc.mozilla.org*
 - [blas](https://github.com/stainless-steel/blas) provides an interface to the Basic Linear Algebra Subprograms
 - [lapack](https://github.com/stainless-steel/lapack) provides an interface to the Linear Algebra PACKage
 - [nalgebra](http://nalgebra.org/) Linear algebra library
-- [ndarray](https://bluss.github.io/rust-ndarray/master/ndarray/index.html) provides an N-dimensional container for general elements and for numerics.
+- [ndarray](https://docs.rs/ndarray) provides an N-dimensional container for general elements and for numerics.
 - [rulinalg](https://github.com/AtheMathmo/rulinalg/) a linear algebra library written in Rust that doesn't require heavy external dependencies.
 
 ## simulation


### PR DESCRIPTION
- [ndarray](https://bluss.github.io/rust-ndarray/master/ndarray/index.html)   update to  https://docs.rs/ndarray
bluss.github.io is old. It was all moved to docs.rs